### PR TITLE
fix: correct .env file location in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,14 @@ Drop-in AI chat widget for any website. Works with OpenAI, Claude, Gemini, GigaC
 ```bash
 git clone https://github.com/gmen1057/ai-chat-widget.git
 cd ai-chat-widget
+
+# For Docker (recommended):
+cp backend/.env.example .env
+
+# For local development:
 cp backend/.env.example backend/.env
-# Edit backend/.env with your AI API key
+
+# Edit .env with your AI API key
 ```
 
 ### 2. Run with Docker (Recommended)
@@ -273,8 +279,8 @@ open demo.html
 
 ```bash
 # Configure
-cp backend/.env.example backend/.env
-# Edit backend/.env
+cp backend/.env.example .env
+# Edit .env with your settings
 
 # Deploy
 docker-compose up -d

--- a/README_RU.md
+++ b/README_RU.md
@@ -27,8 +27,14 @@
 ```bash
 git clone https://github.com/gmen1057/ai-chat-widget.git
 cd ai-chat-widget
+
+# Для Docker (рекомендуется):
+cp backend/.env.example .env
+
+# Для локальной разработки:
 cp backend/.env.example backend/.env
-# Отредактируйте backend/.env — добавьте API ключ
+
+# Отредактируйте .env — добавьте API ключ
 ```
 
 ### 2. Запустите через Docker (рекомендуется)
@@ -195,7 +201,7 @@ DATABASE_URL=postgresql://user:pass@localhost/chatbot
 ### Docker Compose
 
 ```bash
-cp backend/.env.example backend/.env
+cp backend/.env.example .env
 # Отредактируйте .env
 
 docker-compose up -d


### PR DESCRIPTION
## Summary
- Fixed incorrect `.env` file path in Quick Start and Production Deployment sections
- Docker Compose reads `.env` from root directory, not `backend/`
- Added separate instructions for Docker vs local development

## Changes
- **README.md**: Updated Quick Start and Production Deployment sections
- **README_RU.md**: Same updates in Russian version

## Before (incorrect for Docker):
```bash
cp backend/.env.example backend/.env
```

## After (correct):
```bash
# For Docker (recommended):
cp backend/.env.example .env

# For local development:
cp backend/.env.example backend/.env
```

Fixes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)